### PR TITLE
Tests basicos de memoria

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,6 +760,10 @@ dependencies = [
 [[package]]
 name = "memsos_core"
 version = "0.1.0"
+dependencies = [
+ "rand",
+ "rand_chacha",
+]
 
 [[package]]
 name = "noto-sans-mono-bitmap"
@@ -886,6 +890,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy 0.7.35",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +945,35 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_core",
+ "zerocopy 0.8.17",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+dependencies = [
+ "zerocopy 0.8.17",
+]
 
 [[package]]
 name = "regex"
@@ -1532,4 +1574,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
+dependencies = [
+ "zerocopy-derive 0.8.17",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -3,3 +3,7 @@ name = "memsos_core"
 version = "0.1.0"
 edition = "2021"
 
+[dependencies]
+rand = { version = "0.9.0", default-features = false }
+rand_chacha = { version = "0.9.0", default-features = false }
+

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -47,6 +47,10 @@ pub fn run_test<M: Mem, L: Logger>(logger: &L, mem: &M, region: &MemoryRegion) -
 
     result += pattern::run_test_own_address(mem, region);
 
+    logger.ui_change_test("Pattern test, rand number");
+
+    result += pattern::run_test_rand_num(mem, region);
+
     result
     
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -4,12 +4,36 @@ mod test;
 
 use core::fmt::Arguments;
 use crate::test::marchc;
+use core::ops::{Add, AddAssign};
 
-pub fn run_test<M: Mem, L: Logger>(logger: &L, mem: &M, region: &MemoryRegion) {
+pub struct TestResult {
+    pub bad_addrs: u64,
+}
+
+impl Add for TestResult {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self::Output {
+        TestResult { bad_addrs: self.bad_addrs + rhs.bad_addrs  }
+    }
+}
+
+impl AddAssign for TestResult {
+    fn add_assign(&mut self, rhs: Self) {
+        self.bad_addrs += rhs.bad_addrs;
+    }
+}
+
+
+pub fn run_test<M: Mem, L: Logger>(logger: &L, mem: &M, region: &MemoryRegion) -> TestResult {
     logger.log(format_args!("Checking region {:?}", region));
+    let mut result = TestResult {
+        bad_addrs: 0
+    };
 
+    result += marchc::run_march_c(mem, region);
 
-    marchc::run_march_c(mem, region);
+    result
+    
 }
 
 #[derive(Debug)]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,22 +3,45 @@
 use core::fmt::Arguments; 
 
 pub fn run_test<M: Mem, L: Logger>(logger: &L, mem: &M, region: MemoryRegion) {
-    // Simulating a test this should be a real test in the future
-
     logger.log(format_args!("Checking region {:?}", region));
     let offset_region = mem.parse(region);
 
     for addr in offset_region.start..offset_region.end {
         if !mem.check(addr) {
             continue;
-        }        
-
-        mem.write(addr, 2);
-
-        if mem.read(addr) != 2 {
-            panic!("Oh no!");
         }
+        mem.write(addr, 0);
     }
+
+    for addr in offset_region.start..offset_region.end {
+        if !mem.check(addr) {
+            continue;
+        }
+        if mem.read(addr) != 0 {
+            panic!("Test failed at address 1 {:?}", addr);
+        }
+        mem.write(addr, 1);
+    }
+
+    for addr in (offset_region.start..offset_region.end).rev() {
+        if !mem.check(addr) {
+            continue;
+        }
+        if mem.read(addr) != 1 {
+            panic!("Test failed at address 2 {:?}", addr);
+        }
+        mem.write(addr, 0);
+    }
+
+    for addr in offset_region.start..offset_region.end {
+        if !mem.check(addr) {
+            continue;
+        }
+        if mem.read(addr) != 0 {
+            panic!("Test failed at address 3 {:?}", addr);
+        }
+        mem.write(addr, 1);
+    } 
 }
 
 #[derive(Debug)]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -38,7 +38,11 @@ pub fn run_test<M: Mem, L: Logger>(logger: &L, mem: &M, region: &MemoryRegion) -
         bad_addrs: 0
     };
 
+    logger.ui_change_test("March-C");
+
     result += marchc::run_march_c(mem, region);
+
+    logger.ui_change_test("Pattern test, own address");
 
     result
     
@@ -59,4 +63,5 @@ pub trait Mem {
 
 pub trait Logger {
     fn log(&self, message: Arguments<'_>);
+    fn ui_change_test(&self, test: &str);
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -33,7 +33,7 @@ impl AddAssign for TestResult {
 }
 
 
-pub fn run_test<M: Mem, L: Logger>(logger: &L, mem: &M, region: &MemoryRegion) -> TestResult {
+pub fn run_test<M: Mem, L: Logger>(logger: &mut L, mem: &M, region: &MemoryRegion) -> TestResult {
     logger.log(format_args!("Checking region {:?}", region));
     let mut result = TestResult {
         bad_addrs: 0
@@ -70,5 +70,5 @@ pub trait Mem {
 
 pub trait Logger {
     fn log(&self, message: Arguments<'_>);
-    fn ui_change_test(&self, test: &str);
+    fn ui_change_test(&mut self, test: &str);
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,6 +10,14 @@ pub struct TestResult {
     pub bad_addrs: u64,
 }
 
+impl TestResult {
+    pub fn new() -> Self {
+        Self {
+            bad_addrs: 0,
+        }
+    }
+}
+
 impl Add for TestResult {
     type Output = Self;
     fn add(self, rhs: Self) -> Self::Output {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -4,6 +4,7 @@ mod test;
 
 use core::fmt::Arguments;
 use crate::test::marchc;
+use crate::test::pattern;
 use core::ops::{Add, AddAssign};
 
 pub struct TestResult {
@@ -43,6 +44,8 @@ pub fn run_test<M: Mem, L: Logger>(logger: &L, mem: &M, region: &MemoryRegion) -
     result += marchc::run_march_c(mem, region);
 
     logger.ui_change_test("Pattern test, own address");
+
+    result += pattern::run_test_own_address(mem, region);
 
     result
     

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,47 +1,15 @@
 #![no_std]
 
-use core::fmt::Arguments; 
+mod test;
 
-pub fn run_test<M: Mem, L: Logger>(logger: &L, mem: &M, region: MemoryRegion) {
+use core::fmt::Arguments;
+use crate::test::marchc;
+
+pub fn run_test<M: Mem, L: Logger>(logger: &L, mem: &M, region: &MemoryRegion) {
     logger.log(format_args!("Checking region {:?}", region));
-    let offset_region = mem.parse(region);
 
-    for addr in offset_region.start..offset_region.end {
-        if !mem.check(addr) {
-            continue;
-        }
-        mem.write(addr, 0);
-    }
 
-    for addr in offset_region.start..offset_region.end {
-        if !mem.check(addr) {
-            continue;
-        }
-        if mem.read(addr) != 0 {
-            panic!("Test failed at address 1 {:?}", addr);
-        }
-        mem.write(addr, 1);
-    }
-
-    for addr in (offset_region.start..offset_region.end).rev() {
-        if !mem.check(addr) {
-            continue;
-        }
-        if mem.read(addr) != 1 {
-            panic!("Test failed at address 2 {:?}", addr);
-        }
-        mem.write(addr, 0);
-    }
-
-    for addr in offset_region.start..offset_region.end {
-        if !mem.check(addr) {
-            continue;
-        }
-        if mem.read(addr) != 0 {
-            panic!("Test failed at address 3 {:?}", addr);
-        }
-        mem.write(addr, 1);
-    } 
+    marchc::run_march_c(mem, region);
 }
 
 #[derive(Debug)]
@@ -51,7 +19,7 @@ pub struct MemoryRegion {
 }
 
 pub trait Mem {
-    fn parse(&self, region: MemoryRegion) -> MemoryRegion;
+    fn parse(&self, region: &MemoryRegion) -> MemoryRegion;
     fn check(&self, addr: u64) -> bool;
     fn read(&self, addr: u64) -> u64;
     fn write(&self, addr: u64, value: u64);
@@ -60,4 +28,3 @@ pub trait Mem {
 pub trait Logger {
     fn log(&self, message: Arguments<'_>);
 }
-

--- a/crates/core/src/test/marchc.rs
+++ b/crates/core/src/test/marchc.rs
@@ -1,0 +1,42 @@
+use crate::{Mem, MemoryRegion};
+
+pub fn run_march_c<M: Mem>(mem: &M, region: &MemoryRegion) {
+    let offset_region = mem.parse(region);
+
+    for addr in offset_region.start..offset_region.end {
+        if !mem.check(addr) {
+            continue;
+        }
+        mem.write(addr, 0);
+    }
+
+    for addr in offset_region.start..offset_region.end {
+        if !mem.check(addr) {
+            continue;
+        }
+        if mem.read(addr) != 0 {
+            panic!("Test failed at address 1 {:?}", addr);
+        }
+        mem.write(addr, 1);
+    }
+
+    for addr in (offset_region.start..offset_region.end).rev() {
+        if !mem.check(addr) {
+            continue;
+        }
+        if mem.read(addr) != 1 {
+            panic!("Test failed at address 2 {:?}", addr);
+        }
+        mem.write(addr, 0);
+    }
+
+    for addr in offset_region.start..offset_region.end {
+        if !mem.check(addr) {
+            continue;
+        }
+        if mem.read(addr) != 0 {
+            panic!("Test failed at address 3 {:?}", addr);
+        }
+        mem.write(addr, 1);
+    }
+}

--- a/crates/core/src/test/marchc.rs
+++ b/crates/core/src/test/marchc.rs
@@ -1,7 +1,8 @@
-use crate::{Mem, MemoryRegion};
+use crate::{Mem, MemoryRegion, TestResult};
 
-pub fn run_march_c<M: Mem>(mem: &M, region: &MemoryRegion) {
+pub fn run_march_c<M: Mem>(mem: &M, region: &MemoryRegion) -> TestResult {
     let offset_region = mem.parse(region);
+    let mut bad_addrs = 0;
 
     for addr in offset_region.start..offset_region.end {
         if !mem.check(addr) {
@@ -15,7 +16,7 @@ pub fn run_march_c<M: Mem>(mem: &M, region: &MemoryRegion) {
             continue;
         }
         if mem.read(addr) != 0 {
-            panic!("Test failed at address 1 {:?}", addr);
+            bad_addrs += 1;   
         }
         mem.write(addr, 1);
     }
@@ -25,7 +26,7 @@ pub fn run_march_c<M: Mem>(mem: &M, region: &MemoryRegion) {
             continue;
         }
         if mem.read(addr) != 1 {
-            panic!("Test failed at address 2 {:?}", addr);
+           bad_addrs += 1; 
         }
         mem.write(addr, 0);
     }
@@ -35,8 +36,10 @@ pub fn run_march_c<M: Mem>(mem: &M, region: &MemoryRegion) {
             continue;
         }
         if mem.read(addr) != 0 {
-            panic!("Test failed at address 3 {:?}", addr);
+            bad_addrs += 1;    
         }
         mem.write(addr, 1);
     }
+
+    TestResult { bad_addrs }
 }

--- a/crates/core/src/test/mod.rs
+++ b/crates/core/src/test/mod.rs
@@ -1,1 +1,2 @@
 pub mod marchc;
+pub mod pattern;

--- a/crates/core/src/test/mod.rs
+++ b/crates/core/src/test/mod.rs
@@ -1,0 +1,1 @@
+pub mod marchc;

--- a/crates/core/src/test/pattern.rs
+++ b/crates/core/src/test/pattern.rs
@@ -1,4 +1,6 @@
 use crate::{Mem, MemoryRegion, TestResult};
+use rand::{SeedableRng, RngCore};
+use rand_chacha::ChaCha20Rng;
 
 pub fn run_test_own_address<M: Mem>(mem: &M, region: &MemoryRegion) -> TestResult {
     let offset_region = mem.parse(&region);
@@ -20,4 +22,28 @@ pub fn run_test_own_address<M: Mem>(mem: &M, region: &MemoryRegion) -> TestResul
         bad_addrs
     }
 }
+
+pub fn run_test_rand_num<M: Mem>(mem: &M, region: &MemoryRegion) -> TestResult {
+    let offset_region = mem.parse(&region);
+    let mut rand = ChaCha20Rng::seed_from_u64(12381293);
+    let mut bad_addrs = 0;
+
+    for addr in offset_region.start..offset_region.end {
+        let pattern = &rand.next_u64();
+        if !mem.check(addr) {
+            continue;
+        }     
+
+        mem.write(addr, *pattern);
+        
+        if mem.read(addr) != *pattern {
+            bad_addrs += 1;
+        }
+    } 
+
+    TestResult {
+        bad_addrs
+    }
+}
+
 

--- a/crates/core/src/test/pattern.rs
+++ b/crates/core/src/test/pattern.rs
@@ -1,0 +1,23 @@
+use crate::{Mem, MemoryRegion, TestResult};
+
+pub fn run_test_own_address<M: Mem>(mem: &M, region: &MemoryRegion) -> TestResult {
+    let offset_region = mem.parse(&region);
+    let mut bad_addrs = 0;
+
+    for addr in offset_region.start..offset_region.end {
+        if !mem.check(addr) {
+            continue;
+        }     
+
+        mem.write(addr, addr);
+        
+        if mem.read(addr) != addr {
+            bad_addrs += 1;
+        }
+    } 
+
+    TestResult {
+        bad_addrs
+    }
+}
+

--- a/crates/core/src/test/pattern.rs
+++ b/crates/core/src/test/pattern.rs
@@ -25,6 +25,8 @@ pub fn run_test_own_address<M: Mem>(mem: &M, region: &MemoryRegion) -> TestResul
 
 pub fn run_test_rand_num<M: Mem>(mem: &M, region: &MemoryRegion) -> TestResult {
     let offset_region = mem.parse(&region);
+    // TODO: make this dynamic
+    // https://github.com/RustLangES/memsos/pull/8
     let mut rand = ChaCha20Rng::seed_from_u64(12381293);
     let mut bad_addrs = 0;
 

--- a/crates/os/src/drivers/keyboard.rs
+++ b/crates/os/src/drivers/keyboard.rs
@@ -10,6 +10,7 @@ pub struct Keyboard;
 impl Driver for Keyboard {
     type ReadOutput = Event;
     fn read(&self) -> Self::ReadOutput {
+        KEYBOARD_CTRL.write(0xFF);
         while KEYBOARD_CTRL.read() & 0x01 == 0 {}
         let scancode = KEYBOARD_PORT.read();
 

--- a/crates/os/src/mem/mod.rs
+++ b/crates/os/src/mem/mod.rs
@@ -12,9 +12,7 @@ impl Mem for MemWriter {
     fn read(&self, addr: u64) -> u64 {
         let ptr = addr as *mut u64;
 
-        unsafe {
-            ptr.read()
-        }
+        unsafe { ptr.read() }
     }
     fn write(&self, addr: u64, value: u64) {
         let ptr = addr as *mut u64;
@@ -24,14 +22,14 @@ impl Mem for MemWriter {
         }
     }
     fn check(&self, addr: u64) -> bool {
-       let ptr = addr as *mut u64;
-       addr as usize % ALIGNMENT == 0 && !ptr.is_null()
+        let ptr = addr as *mut u64;
+        addr as usize % ALIGNMENT == 0 && !ptr.is_null()
     }
-    fn parse(&self, region: memsos_core::MemoryRegion) -> memsos_core::MemoryRegion {
+    fn parse(&self, region: &memsos_core::MemoryRegion) -> memsos_core::MemoryRegion {
         let offset = self.offset.load(Ordering::SeqCst);
         memsos_core::MemoryRegion {
             start: region.start + offset,
-            end: region.end + offset
+            end: region.end + offset,
         }
     }
 }

--- a/crates/os/src/mem/mod.rs
+++ b/crates/os/src/mem/mod.rs
@@ -1,11 +1,10 @@
-use core::sync::atomic::{AtomicU64, Ordering};
 use memsos_core::Mem;
 
 const ALIGNMENT: usize = core::mem::align_of::<u64>();
 
 #[derive(Debug)]
 pub struct MemWriter {
-    offset: AtomicU64,
+    offset: u64,
 }
 
 impl Mem for MemWriter {
@@ -26,10 +25,9 @@ impl Mem for MemWriter {
         addr as usize % ALIGNMENT == 0 && !ptr.is_null()
     }
     fn parse(&self, region: &memsos_core::MemoryRegion) -> memsos_core::MemoryRegion {
-        let offset = self.offset.load(Ordering::SeqCst);
         memsos_core::MemoryRegion {
-            start: region.start + offset,
-            end: region.end + offset,
+            start: region.start + self.offset,
+            end: region.end + self.offset,
         }
     }
 }
@@ -37,7 +35,7 @@ impl Mem for MemWriter {
 impl MemWriter {
     pub const fn create(offset: u64) -> Self {
         Self {
-            offset: AtomicU64::new(offset),
+            offset,
         }
     }
 }

--- a/crates/os/src/ui/logger.rs
+++ b/crates/os/src/ui/logger.rs
@@ -1,7 +1,9 @@
 // Implementation of the Logger trait in core
 use crate::ui::layout::{vertical::VerticalLayout, Layout};
+use crate::ui::writer::get_ui;
 use crate::{layout, text};
 use memsos_core::Logger;
+use crate::render;
 
 pub struct DebugLogger<'a> {
     pub debug_layout: &'a VerticalLayout,
@@ -18,5 +20,13 @@ impl<'a> DebugLogger<'a> {
 impl Logger for DebugLogger<'_> {
     fn log(&self, message: core::fmt::Arguments<'_>) {
         layout!(self.debug_layout, &text!("{message}"));
+    }
+    fn ui_change_test(&self, test: &str) {
+        let ui = get_ui();
+        let test_text = text!((ui.width() - (ui.width() / 2) + 6, 50), "Actual test: {}", test);
+
+        render!(
+            &test_text
+        );
     }
 }

--- a/crates/os/src/ui/logger.rs
+++ b/crates/os/src/ui/logger.rs
@@ -3,7 +3,7 @@ use crate::ui::layout::{vertical::VerticalLayout, Layout};
 use crate::ui::writer::get_ui;
 use crate::{layout, text};
 use memsos_core::Logger;
-use crate::render;
+use crate::{erase, render};
 
 pub struct DebugLogger<'a> {
     pub debug_layout: &'a VerticalLayout,
@@ -24,6 +24,8 @@ impl Logger for DebugLogger<'_> {
     fn ui_change_test(&self, test: &str) {
         let ui = get_ui();
         let test_text = text!((ui.width() - (ui.width() / 2) + 6, 50), "Actual test: {}", test);
+            
+        erase!(&test_text);
 
         render!(
             &test_text

--- a/crates/os/src/ui/logger.rs
+++ b/crates/os/src/ui/logger.rs
@@ -4,15 +4,18 @@ use crate::ui::writer::get_ui;
 use crate::{layout, text};
 use memsos_core::Logger;
 use crate::{erase, render};
+use crate::ui::widget::text::Text;
 
 pub struct DebugLogger<'a> {
     pub debug_layout: &'a VerticalLayout,
+    pub actual_test: Text
 }
 
 impl<'a> DebugLogger<'a> {
     pub fn new(layout: &'a VerticalLayout) -> Self {
         Self {
             debug_layout: layout,
+            actual_test: text!(""),
         }
     }
 }
@@ -21,14 +24,15 @@ impl Logger for DebugLogger<'_> {
     fn log(&self, message: core::fmt::Arguments<'_>) {
         layout!(self.debug_layout, &text!("{message}"));
     }
-    fn ui_change_test(&self, test: &str) {
+    fn ui_change_test(&mut self, test: &str) {
         let ui = get_ui();
-        let test_text = text!((ui.width() - (ui.width() / 2) + 6, 50), "Actual test: {}", test);
-            
-        erase!(&test_text);
+        
+        erase!(&self.actual_test);
+
+        self.actual_test = text!((ui.width() - (ui.width() / 2) + 6, 50), "Actual test: {}", test);
 
         render!(
-            &test_text
+            &self.actual_test
         );
     }
 }

--- a/crates/os/src/ui/widget/text.rs
+++ b/crates/os/src/ui/widget/text.rs
@@ -80,6 +80,10 @@ impl Text {
             _ => p,
         };
 
+        if c == '\n' {
+            return pos;
+        }
+
         let new_xpos = pos.0 + CHAR_RASTER_WIDTH;
         let new_ypos = pos.1 + CHAR_RASTER_HEIGHT.val() + BORDER_PADDING;
         if new_ypos >= writer.height() {

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -11,7 +11,7 @@ use os::{
     mem::MemWriter,
     power::reboot::reboot,
     ui::{
-        layout::{vertical::VerticalLayout, Layout, LayoutParams},
+        layout::{vertical::VerticalLayout, Layout, LayoutParams, LayoutChild},
         logger::DebugLogger,
         widget::{input::input, line::line},
         writer::{clear, init_ui},
@@ -66,10 +66,13 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
         max_y: None,
     });
 
+    let memtest_message = text!((info.width - (info.width / 2) + 6, 30), "Memtest");
+    let mut test_text = text!((info.width - (info.width / 2) + 6, 50), "Test: March-C");
+
     let test_info_layout = VerticalLayout::new(LayoutParams {
         padding: 0,
         line_size: None,
-        start_pos: (info.width - (info.width / 2) + 6, 30),
+        start_pos: (info.width - (info.width / 2) + 6, 70),
         max_y: None,
     });
 
@@ -83,10 +86,15 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
         &line((PADDING, h / 2), (w - PADDING, h / 2)),
         &line((w / 2, PADDING), (w / 2, h / 2))
     );
+    
+    render!(
+        &memtest_message,
+        &test_text
+    );
 
     layout!(
         test_info_layout,
-        &text!("Memtest info\n test")
+        &text!("here you should see information about the processor ram and others")
     );
 
     layout!(

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -66,6 +66,13 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
         max_y: None,
     });
 
+    let test_info_layout = VerticalLayout::new(LayoutParams {
+        padding: 0,
+        line_size: None,
+        start_pos: (info.width - (info.width / 2) + 6, 30),
+        max_y: None,
+    });
+
     clear();
 
     render!(
@@ -75,6 +82,11 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
         &line((PADDING, PADDING), (w - PADDING, PADDING)),
         &line((PADDING, h / 2), (w - PADDING, h / 2)),
         &line((w / 2, PADDING), (w / 2, h / 2))
+    );
+
+    layout!(
+        test_info_layout,
+        &text!("Memtest info")
     );
 
     layout!(

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -11,7 +11,7 @@ use os::{
     mem::MemWriter,
     power::reboot::reboot,
     ui::{
-        layout::{vertical::VerticalLayout, Layout, LayoutParams, LayoutChild},
+        layout::{vertical::VerticalLayout, Layout, LayoutParams},
         logger::DebugLogger,
         widget::{input::input, line::line},
         writer::{clear, init_ui},
@@ -19,7 +19,7 @@ use os::{
     PADDING,
 };
 
-use memsos_core::{run_test, MemoryRegion};
+use memsos_core::{run_test, MemoryRegion, TestResult};
 
 const CONFIG: BootloaderConfig = {
     let mut config = bootloader_api::BootloaderConfig::new_default();
@@ -111,6 +111,8 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
         &text!("Made with love by Rust Lang Es")
     );
 
+    let mut test_result = TestResult::new(); 
+
     for region in regions.iter() {
         if region.kind != MemoryRegionKind::Usable {
             layout!(
@@ -119,7 +121,7 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
             );
             continue;
         }
-        run_test(
+        test_result += run_test(
             &logger,
             &memory_writer,
             &MemoryRegion {
@@ -128,7 +130,13 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
             },
         );
     }
-
+    
+    layout!(
+        &test_info_layout,
+        &text!("Test Completed..."),
+        &text!((0,0), "Number of faulty memory addrs {}", test_result.bad_addrs)
+    );
+        
     loop {}
 }
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -57,7 +57,7 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
         max_y: Some((h - PADDING).try_into().unwrap()),
     });
 
-    let logger = DebugLogger::new(&debug_layout);
+    let mut logger = DebugLogger::new(&debug_layout);
 
     let info_layout = VerticalLayout::new(LayoutParams {
         padding: 0,
@@ -120,7 +120,7 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
             continue;
         }
         test_result += run_test(
-            &logger,
+            &mut logger,
             &memory_writer,
             &MemoryRegion {
                 start: region.start,

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -6,21 +6,18 @@ use bootloader_api::{
 };
 use core::panic::PanicInfo;
 
+use os::{layout, render, text};
 use os::{
-   power::reboot::reboot,
-   ui::{
-      widget::{
-        line::line,
-        input::input
-      },
-      layout::{vertical::VerticalLayout, Layout, LayoutParams},
-      logger::DebugLogger,
-      writer::{clear, init_ui},
-   },
-   mem::MemWriter,
-   PADDING
+    mem::MemWriter,
+    power::reboot::reboot,
+    ui::{
+        layout::{vertical::VerticalLayout, Layout, LayoutParams},
+        logger::DebugLogger,
+        widget::{input::input, line::line},
+        writer::{clear, init_ui},
+    },
+    PADDING,
 };
-use os::{text, layout, render};
 
 use memsos_core::{run_test, MemoryRegion};
 
@@ -105,7 +102,7 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
         run_test(
             &logger,
             &memory_writer,
-            MemoryRegion {
+            &MemoryRegion {
                 start: region.start,
                 end: region.end,
             },

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -67,8 +67,7 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
     });
 
     let memtest_message = text!((info.width - (info.width / 2) + 6, 30), "Memtest");
-    let mut test_text = text!((info.width - (info.width / 2) + 6, 50), "Test: March-C");
-
+  
     let test_info_layout = VerticalLayout::new(LayoutParams {
         padding: 0,
         line_size: None,
@@ -88,8 +87,7 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
     );
     
     render!(
-        &memtest_message,
-        &test_text
+        &memtest_message
     );
 
     layout!(

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -86,7 +86,7 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
 
     layout!(
         test_info_layout,
-        &text!("Memtest info")
+        &text!("Memtest info\n test")
     );
 
     layout!(


### PR DESCRIPTION
Esta pull requests agrega tests basicos de memoria RAM a memsos y además muestra cuando terminan los tests y las direcciones defectuosas, actualmente solo está un test, pero en otras pull requests se irán agregando más

- Se agrega el tests march-c
- Se agregan dos tests mas basados en patterns
- Mostrar el tests actual en pantalla
- Se usa el tests para las regiones usables de la memoria (esto para no romper al kernel debido que si se escriben en las direcciones donde esta el kernel dejaria de funcionar)
- Se modifican ciertas cosas en memsos-core para tener mas sentido al momento de escribir/leer en la memoria