### PR TITLE
chore(ci): trigger workflow on push to dev

### DIFF
--- a/.github/workflows/ovmf-update.yml
+++ b/.github/workflows/ovmf-update.yml
@@ -2,6 +2,9 @@ name: Update ovmf hashes
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - dev
   schedule:
     - cron: "0 * * * *"
 


### PR DESCRIPTION
Se añade un trigger de `push` para que el workflow se ejecute automáticamente en cada cambio en `dev`.
