### PR TITLE
Remover .cargo

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[unstable]
-bindeps = true


### PR DESCRIPTION
Esta pull request es bastante sencilla simplemente elimina el directorio .cargo, que era innecesario. Memsos sigue funcionando como siempre y no hubo ningún cambio en su comportamiento.
    